### PR TITLE
add a condition in CryptoVerifyTAPbkdf2.c to prevent buffer overflow

### DIFF
--- a/ta/CryptoVerifyTaPbkdf2.c
+++ b/ta/CryptoVerifyTaPbkdf2.c
@@ -261,6 +261,12 @@ void g_CryptoTaPbkdf_PBKDF2(CHAR P[],int Plen, CHAR S[], int Slen, int c,int dkL
     } 
 
     /**4) Copy the result data into output buffer */
+
+    if (dkLen > 512) 
+    {
+        return TEE_ERROR_BAD_PARAMETERS;
+    }
+
     TEE_MemMove(output, resultBuf, dkLen);
 }
 


### PR DESCRIPTION
This pull request addresses a potential security issue caused by missing validation checks in the TA code. Since params[0].memref comes from the insecure REE , the TA code should check malicious inputs, such as params[0].memref.size bigger than 512 bytes that may cause buffer overflow.
Please kindly consider our pull request, many thanks!